### PR TITLE
Prevent removing unintended files by Symfony Finder

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -28,8 +28,7 @@
   "ignore": [
     "*",
     "**/.*",
-    "!/dist/*.js",
-    "!/dist/*.css",
+    "!/dist/**",
     "!/CHANGELOG.*",
     "!/LICENSE.*",
     "!/README.*"


### PR DESCRIPTION
As:
- reported in https://github.com/fullcalendar/fullcalendar-scheduler/issues/21
- suggested in https://github.com/francoispluchino/composer-asset-plugin/issues/147#issuecomment-141910164

Symfony Finder processes the filters in the ignore section slightly different. Now adopted the rules as used in https://github.com/fullcalendar/fullcalendar/blob/master/bower.json#L41-L51