### PR TITLE
Add ClassName to ResourceCellHtml

### DIFF
--- a/src/common/ResourceDayTableMixin.coffee
+++ b/src/common/ResourceDayTableMixin.coffee
@@ -168,7 +168,11 @@ ResourceDayTableMixin =
 
 	# given a resource and an optional date
 	renderHeadResourceCellHtml: (resource, date, colspan) ->
-		'<th class="fc-resource-cell"' +
+		'<th class="fc-resource-cell' +
+			(if resource.cellClassName
+				' ' + resource.cellClassName + '"'
+			else
+				'"') +
 			' data-resource-id="' + resource.id + '"' +
 			(if date
 				' data-date="' + date.format('YYYY-MM-DD') + '"'


### PR DESCRIPTION
Add the possibility to add a class name to the th cell depending the resource.
exemple :
resource :  [
    {
        id: 'a',
        title: 'Room A',
        cellClassName: 'backup'
    },
    {
        id: 'b',
        title: 'Room B',
        cellClassName : 'first'
    }]

HTML result :
<th class="fc-resource-cell backup" data-resource-id="a">Room A</th>
<th class="fc-resource-cell first" data-resource-id="b">Room B</th>