### PR TITLE
Potential fix for intended behavior of triggering loading state

### DIFF
--- a/src/ResourceManager.coffee
+++ b/src/ResourceManager.coffee
@@ -76,7 +76,7 @@ class ResourceManager extends Class
 
 		promise or= deferred.promise()
 
-		if not promise.state() == 'pending'
+		if promise.state() == 'pending'
 			@calendar.pushLoading()
 			promise.always ->
 				@calendar.popLoading()


### PR DESCRIPTION
In the function fetchResourceInputs from the RessourceManager, you are currently checking :

``` coffeescript
if not promise.state() == 'pending'
			@calendar.pushLoading()
			promise.always ->
				@calendar.popLoading()
```

I don't think it will ever trigger the loading state, quick fix is to remove the negation.