### PR TITLE
Add composer.js to let PHP developers to keep track of fullcalendar-scheduler on packagist.org.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,25 @@
+{
+    "name": "fullcalendar/fullcalendar-scheduler",
+    "description": "A premium add-on to FullCalendar for displaying events and resources",
+    "authors": [
+        {
+          "name": "Adam Shaw",
+          "email": "arshaw@arshaw.com",
+          "homepage": "http://arshaw.com/"
+        }
+    ],
+    "keywords": [
+        "calendar",
+        "event",
+        "full-sized",
+        "jquery-plugin"
+    ],
+    "type": "library",
+    "minimum-stability": "stable",
+    "homepage": "https://fullcalendar.io/scheduler/",
+    "require": {
+        "components/jquery": "^3.1.0",
+        "moment/moment": "^2.9.0",
+        "fullcalendar/fullcalendar": "~3.3.1"
+    }
+}


### PR DESCRIPTION
Hi,

This is related to [fullcalendar#2999](https://github.com/fullcalendar/fullcalendar/issues/2999) and [fullcalendar#3617](https://github.com/fullcalendar/fullcalendar/pull/3617).

As I did for fullcalendar, here is another pull-request for `composer.json` file. I omitted license information, because I couldn't find the correct value for "Copyright".