### PR TITLE
Allow supplying a callback function for slotLabelFormat

### DIFF
--- a/src/timeline/TimelineView.defaults.ts
+++ b/src/timeline/TimelineView.defaults.ts
@@ -45,7 +45,7 @@ export function initScaleProps(timelineView: TimelineView) {
   timelineView.headerFormats =
     type === 'array' ?
       input
-    : type === 'string' ?
+    : type === 'string' || type === 'function' ?
       [ input ]
     :
       computeHeaderFormats(timelineView)

--- a/src/timeline/TimelineView.ts
+++ b/src/timeline/TimelineView.ts
@@ -3,7 +3,7 @@ import * as moment from 'moment'
 import {
   View, UnzonedRange, ComponentFootprint,
   proxy, CoordCache, queryMostGranularFormatUnit,
-  isInt, divideRangeByDuration, htmlEscape, computeGreatestUnit,
+  isInt, divideRangeByDuration, computeGreatestUnit,
   divideDurationByDuration, multiplyDuration, StandardInteractionsMixin,
   BusinessHourRenderer
 } from 'fullcalendar'
@@ -419,7 +419,7 @@ export default class TimelineView extends View {
         let newCell = null
 
         if (isSuperRow) {
-          let text = date.format(format)
+          let text = (typeof format === 'function') ? format(date) : date.format(format)
           if (!leadingCell || (leadingCell.text !== text)) {
             newCell = this.buildCellObject(date, text, rowUnits[row])
           } else {
@@ -427,7 +427,7 @@ export default class TimelineView extends View {
           }
         } else {
           if (!leadingCell || isInt(divideRangeByDuration(this.normalizedUnzonedStart, date, labelInterval))) {
-            let text = date.format(format)
+            let text = (typeof format === 'function') ? format(date) : date.format(format)
             newCell = this.buildCellObject(date, text, rowUnits[row])
           } else {
             leadingCell.colspan += 1
@@ -515,7 +515,7 @@ export default class TimelineView extends View {
       {
         'class': 'fc-cell-text'
       },
-      htmlEscape(text)
+      text
     )
     return { text, spanHtml, date, colspan: 1 }
   }


### PR DESCRIPTION
In the timeline view, specifically in the resource timeline view, it is currently impossible to add arbitrary content to the slot labels, i.e. the "date field". It is only possible to specify a date format string, which is then passed into `moment().format(...)`.

As already discussed in #429, it can be desirable to exercise more control over the slot label, e.g. to add custom information. This PR adds that functionality by allowing callbacks for `slotLabelFormat`. I attach a screenshot showing holiday names underneath the date, which I generated with the following example code snippet:

```javascript
$calendar.fullCalendar({
  views: {
    timelineMonth: {
      type: 'timeline',
      slotLabelFormat: ['MMMM', function (date) {
        if (!date) { return ''; }
        var holiday = holidays.find(function (h) { return h.date === date.format('YYYY-MM-DD'); });
        return date.format('dd DD') + (holiday ? '<br />' + holiday.name : '');
      }]
    }
  },
  ...
});
```

![bildschirmfoto vom 2018-10-18 16-22-40](https://user-images.githubusercontent.com/1872086/47161291-0efa3f80-d2f2-11e8-8184-3a4aa51eb882.png)

The API still allows date format strings, and uses Moment in that case. Furthermore, supplying format modifiers / callbacks for several levels of headers as an array is still supported.

If you would prefer a different API or some other changes, please hit me up again, I would be glad if I can contribute.