### PR TITLE
Fix rerendering resources when there were none before.

### DIFF
--- a/src/resource-common/option-change-handlers.ts
+++ b/src/resource-common/option-change-handlers.ts
@@ -5,9 +5,9 @@ export default {
 }
 
 function handleResources(newSourceInput, calendar: Calendar) {
-  let oldSourceInput = calendar.state.resourceSource._raw
+  const oldSourceInput = calendar.state.resourceSource
 
-  if (!isValuesSimilar(oldSourceInput, newSourceInput, 2)) {
+  if (!oldSourceInput || !isValuesSimilar(oldSourceInput._raw, newSourceInput, 2)) {
     calendar.dispatch({
       type: 'RESET_RESOURCE_SOURCE',
       resourceSourceInput: newSourceInput

--- a/tests/automated/misc/setOptions-resetOptions.js
+++ b/tests/automated/misc/setOptions-resetOptions.js
@@ -58,6 +58,17 @@ describeValues({
     expect(calendar.getResources().length).toBe(resources.length)
   })
 
+  it('rerenders resources when there were no resources before', function() {
+    let options = buildOptions()
+    options.resources = null
+
+    calendar = new Calendar($calendarEl[0], options)
+    calendar.render()
+
+    mutateOptions(calendar, { resources: [{ id: 'c', title: 'Resource C' }] })
+    expect(calendar.getResources().length).toBe(1)
+  })
+
 })
 
 function mutateOptionsViaChange(calendar, changedOptions) {


### PR DESCRIPTION
This fixes a bug that occurs when:

* You have a calendar with no resource views (e.g. dayGrid)
* You change the calendar views to have resource views (e.g. resourceTimelineDay)