### PR TITLE
Show non-parsed businessHours as part of ResourceObject

### DIFF
--- a/src/resource-common/api/ResourceApi.ts
+++ b/src/resource-common/api/ResourceApi.ts
@@ -92,5 +92,6 @@ export default class ResourceApi {
   // NOTE: user can't modify these because Object.freeze was called in event-def parsing
   get eventClassNames(): string[] { return this._resource.ui.classNames }
   get extendedProps(): any { return this._resource.extendedProps }
+  get businessHours(): any { return this._resource.businessHoursProps }
 
 }

--- a/src/resource-common/structs/resource.ts
+++ b/src/resource-common/structs/resource.ts
@@ -30,7 +30,8 @@ export interface Resource {
   title: string
   businessHours: EventStore | null
   ui: EventUi
-  extendedProps: { [extendedProp: string]: any }
+  extendedProps: { [extendedProp: string]: any },
+  businessHoursProps?: any
 }
 
 export type ResourceHash = { [resourceId: string]: Resource }
@@ -63,7 +64,7 @@ export function parseResource(input: ResourceInput, parentId: string = '', store
   if (!props.parentId) { // give precedence to the parentId property
     props.parentId = parentId
   }
-
+  props['businessHoursProps'] = props.businessHours ? props.businessHours : null
   props.businessHours = props.businessHours ? parseBusinessHours(props.businessHours, calendar) : null
   props.ui = ui
   props.extendedProps = { ...leftovers1, ...props.extendedProps }
@@ -71,6 +72,7 @@ export function parseResource(input: ResourceInput, parentId: string = '', store
   // help out ResourceApi from having user modify props
   Object.freeze(ui.classNames)
   Object.freeze(props.extendedProps)
+  Object.freeze(props['businessHoursProps'])
 
   if (store[props.id]) {
     // console.warn('duplicate resource ID')


### PR DESCRIPTION
This is a pull request made for my own feature request #537.

As this is my first time contributing, please let me know if there is anything else I should make this PR to be approved.

The objective is to give `ResourceApi` the same user inputed `businessHours`, not the parsed one.