### PR TITLE
Check if stickyScrollings[key].updateSize function exists

### DIFF
--- a/scrollgrid/src/ScrollGrid.tsx
+++ b/scrollgrid/src/ScrollGrid.tsx
@@ -523,9 +523,9 @@ export class ScrollGrid extends BaseComponent<ScrollGridProps, ScrollGridState> 
     let stickyScrollings = this.getStickyScrolling(argsByKey)
 
     for (let key in stickyScrollings) {
-		  if(typeof stickyScrollings[key].updateSize == 'function') {
-			  stickyScrollings[key].updateSize()
-		  }
+	if(typeof stickyScrollings[key].updateSize == 'function') {
+		stickyScrollings[key].updateSize()
+	}
     }
 
     this.stickyScrollings = stickyScrollings

--- a/scrollgrid/src/ScrollGrid.tsx
+++ b/scrollgrid/src/ScrollGrid.tsx
@@ -523,7 +523,9 @@ export class ScrollGrid extends BaseComponent<ScrollGridProps, ScrollGridState> 
     let stickyScrollings = this.getStickyScrolling(argsByKey)
 
     for (let key in stickyScrollings) {
-      stickyScrollings[key].updateSize()
+		  if(typeof stickyScrollings[key].updateSize == 'function') {
+			  stickyScrollings[key].updateSize()
+		  }
     }
 
     this.stickyScrollings = stickyScrollings


### PR DESCRIPTION
Updates scrollgrid to check if the stickyScrollings[key].updateSize function exists before running it. This resolves a problem when running in a Salesforce Visualforce environment that utilizes remoting.  Yes, we all know the function exists, but there is some quantum Schrodinger's cat voodoo going on over in Salesforce land and it just doesn't work unless you look for it first.

Fixes #5601 