### PR TITLE
Make sticky scrolling behavior more resilient in 3rd party environments

### DIFF
--- a/scrollgrid/src/ScrollGrid.tsx
+++ b/scrollgrid/src/ScrollGrid.tsx
@@ -518,9 +518,7 @@ export class ScrollGrid extends BaseComponent<ScrollGridProps, ScrollGridState> 
 
     let stickyScrollings = this.getStickyScrolling(argsByKey)
 
-    for (let key in stickyScrollings) {
-      stickyScrollings[key].updateSize()
-    }
+    stickyScrollings.forEach(stickyScrolling => stickyScrolling.updateSize())
 
     this.stickyScrollings = stickyScrollings
   }


### PR DESCRIPTION
Fixes: https://github.com/fullcalendar/fullcalendar/issues/5752
Fixes: https://github.com/fullcalendar/fullcalendar/issues/5601
Fixes: https://github.com/fullcalendar/fullcalendar-scheduler/pull/567

**Description**
The ScrollGrid module fails with the error `updateSize is not a function` and causes the scheduler to stop rendering events.

**Reduced Test Case**
https://codepen.io/pixel9/pen/rNemOGr

**Steps to Reproduce**
- scheduler is configured with setting `height: '100%'` (to activate sticky scrolling behavior)
- scheduler is running in an environment where `Array.prototype` has been modified (by a polyfill for example)

**Analysis**
This is not specific to Salesforce or any other "weird" environment. Using `for...in` on the `stickyScrollings` array is unintentionally including extra keys in environments where the `Array.prototype` has been modified. Using `.forEach` fixes the problem and is also[ consistent with how `stickyScrollings` is iterated in the rest of the module](https://github.com/fullcalendar/fullcalendar-scheduler/blob/7f0aec653338d0041e289ca075180c4d7ce04b0a/scrollgrid/src/ScrollGrid.tsx#L530).