### PR TITLE
Export ResourceSourceInputObject, ResourceFunc & ResourceInput

### DIFF
--- a/resource-common/src/api-type-deps.ts
+++ b/resource-common/src/api-type-deps.ts
@@ -1,5 +1,7 @@
 
-export { ResourceSourceInput } from './structs/resource-source-parse'
+export { ResourceSourceInput, ResourceSourceInputObject } from './structs/resource-source-parse'
+import { ResourceFunc } from './resource-sources/resource-func'
+import { ResourceInput } from './structs/resource'
 export { ResourceLabelContentArg, ResourceLabelMountArg } from './common/ResourceLabelRoot'
 export { ColSpec, ColHeaderContentArg, ColHeaderMountArg, ColCellContentArg, ColCellMountArg } from './common/resource-spec'
 export { ResourceLaneContentArg, ResourceLaneMountArg } from './render-hooks'


### PR DESCRIPTION
Makes it easier to type hint resource sources.

Closes https://github.com/fullcalendar/fullcalendar/issues/5797.