### PR TITLE
Fix bower fullcalendar version dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "jquery": "2 - 3",
     "moment": "^2.20.1",
-    "fullcalendar": "~3.9.0"
+    "fullcalendar": "~3.10.0"
   },
   "main": [
     "dist/scheduler.js",


### PR DESCRIPTION
There is a version conflict between fullcalendar-scheduler and fullcalendar on asset packagist. 