### PR TITLE
Fix jumpy dragging when snapDuration !== slotDuration

### DIFF
--- a/standard/packages/timegrid/src/components/TimeGridCols.tsx
+++ b/standard/packages/timegrid/src/components/TimeGridCols.tsx
@@ -121,7 +121,7 @@ export class TimeGridCols extends DateComponent<TimeGridColsProps> { // TODO: re
     const slatTop = slatIndex * slatHeight
     const partial = (positionTop - slatTop) / slatHeight // floating point number between 0 and 1
     const localSnapIndex = Math.floor(partial * snapsPerSlot) // the snap # relative to start of slat
-    const snapIndex = slatIndex + localSnapIndex * snapsPerSlot
+    const snapIndex = slatIndex * snapsPerSlot + localSnapIndex;
 
     const time = addDurations(
       dateProfile.slotMinTime,


### PR DESCRIPTION
Hi! 👋 
      
Firstly, thanks for your work on this project! 🙂

Today I used [patch-package](https://github.com/ds300/patch-package) to patch `@fullcalendar/timegrid@7.0.0-beta.4` for the project I'm working on.

with
```
snapDuration={{ minutes: 15 }}
slotDuration={{ minutes: 30 }}
```
Before: dragging an event up or down is jumpy (up 30 minutes, down 15 minutes, etc) and mouse gets out of sync:

https://github.com/user-attachments/assets/a83f6bc6-c011-4539-a4ad-2d1071edb401

After: smooth and mouse in sync:

https://github.com/user-attachments/assets/da9308c3-7d51-4286-9788-01da286c517a

Here is the diff that solved my problem:

```diff
diff --git a/node_modules/@fullcalendar/timegrid/internal.js b/node_modules/@fullcalendar/timegrid/internal.js
index ac5854a..b7cf5d8 100644
--- a/node_modules/@fullcalendar/timegrid/internal.js
+++ b/node_modules/@fullcalendar/timegrid/internal.js
@@ -684,7 +684,7 @@ class TimeGridCols extends DateComponent {
         const slatTop = slatIndex * slatHeight;
         const partial = (positionTop - slatTop) / slatHeight; // floating point number between 0 and 1
         const localSnapIndex = Math.floor(partial * snapsPerSlot); // the snap # relative to start of slat
-        const snapIndex = slatIndex + localSnapIndex * snapsPerSlot;
+        const snapIndex = slatIndex * snapsPerSlot + localSnapIndex;
         const time = addDurations(dateProfile.slotMinTime, multiplyDuration(snapDuration, snapIndex));
         const start = dateEnv.add(cell.date, time);
         const end = dateEnv.add(start, snapDuration);
```

Maybe this is helpful for https://github.com/fullcalendar/fullcalendar/issues/4865? Or maybe it breaks something.  Haven't tested beyond that it seems to fix my own issue.

Thank you for your hard work!

<em>This issue body was [partially generated by patch-package](https://github.com/ds300/patch-package/issues/296).</em>