### PR TITLE
daygrid: improve selectMirror date selection routing

### DIFF
--- a/standard/packages/preact/src/daygrid/components/DayGridRow.tsx
+++ b/standard/packages/preact/src/daygrid/components/DayGridRow.tsx
@@ -435,6 +435,10 @@ export class DayGridRow extends BaseComponent<DayGridRowProps> {
       return props.eventResize.segs
     }
 
+    if (this.context.options.selectMirror) {
+      return props.dateSelectionSegs
+    }
+
     return []
   }
 
@@ -447,6 +451,10 @@ export class DayGridRow extends BaseComponent<DayGridRowProps> {
 
     if (props.eventResize && props.eventResize.segs.length) { // messy check
       return props.eventResize.segs
+    }
+
+    if (this.context.options.selectMirror) {
+      return []
     }
 
     return props.dateSelectionSegs


### PR DESCRIPTION
## Problem
When `selectMirror` is enabled in daygrid, date selection handling in `DayGridRow` can route selection visuals in a way that does not align with mirror behavior.

Partially referencing this issue: https://github.com/fullcalendar/fullcalendar/issues/2581

## Change
- Update `DayGridRow` selection segment routing to better honor `selectMirror` behavior.
- Keep scope limited to daygrid row handling.

## Scope
- Changed file: `standard/packages/preact/src/daygrid/components/DayGridRow.tsx`
- Base branch: `v7-dev`

## Notes
- Intended behavior with `selectMirror` disabled remains unchanged.
